### PR TITLE
Config Options Fix

### DIFF
--- a/rollup.umd.config.js
+++ b/rollup.umd.config.js
@@ -24,7 +24,7 @@ if (env === 'production') {
       compress: {
         pure_getters: true,
         unsafe: true,
-        unsafe_comps: true,
+        unsafe_comps: true
       },
       warnings: false
     })

--- a/rollup.umd.config.js
+++ b/rollup.umd.config.js
@@ -25,8 +25,8 @@ if (env === 'production') {
         pure_getters: true,
         unsafe: true,
         unsafe_comps: true,
-        warnings: false
-      }
+      },
+      warnings: false
     })
   )
 }


### PR DESCRIPTION
`npm install` fails when you try to use warnings in the `compress` object. You're probably asking yourself why that fails instead of just ignoring the flag. Because why not?